### PR TITLE
Add putOf dependency registration method

### DIFF
--- a/lib/dependency_management/dependency.dart
+++ b/lib/dependency_management/dependency.dart
@@ -91,6 +91,39 @@ class Dependency {
     return _dependencyStore[key];
   }
 
+  /// Registers a dependency under a specific BaseClass interface.
+  ///
+  /// This allows loose coupling. You can register a [ChildClass] but
+  /// retrieve it later using [find<BaseClass>()].
+  ///
+  /// Example:
+  /// ```dart
+  /// Dependency.putOf<DatabaseRepo, SqlDatabaseRepo>(SqlDatabaseRepo());
+  /// ```
+  static S putOf<B, S extends B>(
+    S dependency, {
+    String? tag,
+    bool fenix = false,
+  }) {
+    // Use the Base type 'B' for the key, NOT dependency.runtimeType
+    final key = _getKey(B, tag: tag);
+
+    if (_dependencyStore[key] != null) {
+      Logger.warn(
+        'Dependency of base type $B is being overwritten with $S at runtime',
+        tag: 'Dependency',
+      );
+    }
+
+    _dependencyStore[key] = dependency;
+
+    if (fenix) {
+      _lazyBuilders[key] = () => dependency;
+    }
+
+    return dependency;
+  }
+
   /// Registers a lazy dependency builder.
   ///
   /// The dependency instance is created only when [find] is called for the

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -32,6 +32,10 @@ class TestController extends ReactiveController {
   }
 }
 
+abstract class BaseService {}
+
+class ConcreteService extends BaseService {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -47,6 +51,14 @@ void main() {
 
       final found = Dependency.find<TestController>();
       expect(identical(controller, found), isTrue);
+    });
+
+    test('should putOf and find dependency by base type', () {
+      final service = ConcreteService();
+      Dependency.putOf<BaseService, ConcreteService>(service);
+
+      final found = Dependency.find<BaseService>();
+      expect(identical(service, found), isTrue);
     });
 
     test('should support tagged dependencies', () {


### PR DESCRIPTION
---
name: Pull Request
about: Submit a pull request to contribute to Reactiv
---

## Description

Added a new `putOf<B, S extends B>` method to the `Dependency` class. This facilitates loose coupling by allowing developers to register concrete implementations (like `SqlDatabaseRepo`) but fetch them later using their abstract base class or interface (like `DatabaseRepo`) using `Dependency.find<DatabaseRepo>()`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Related Issues

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have run `dart format` on my changes
- [x] I have run `dart analyze` and fixed all issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`flutter test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md with my changes

## Testing

1. Added `BaseService` (abstract class) and `ConcreteService` (implementation) in `dependency_test.dart`.
2. Created a unit test `should putOf and find dependency by base type` that verifies retrieving the `ConcreteService` instance using `Dependency.find<BaseService>()`. 
3. Ran `flutter test test/dependency_test.dart` successfully.

## Screenshots (if applicable)

N/A

## Additional Notes

This addition heavily promotes SOLID principles (particularly Dependency Inversion) within the Reactiv package, giving developers more modularity when injecting dependencies.